### PR TITLE
small fixes

### DIFF
--- a/src/ed.s
+++ b/src/ed.s
@@ -2,7 +2,7 @@
 ;; Next Editor
 ;;----------------------------------------------------------------------------------------------------------------------
 
-opt     sna=Start:$c000
+opt     sna=Start:$BFFE
 opt     zxnext
 opt     zxnextreg
 
@@ -51,7 +51,7 @@ CMDBUFFER       equ     $bd
         incbin  "data/test.txt"
         db      EOF
 
-textlen equ * - $c000
+textlen equ PC - $c000
 
 
 ;;----------------------------------------------------------------------------------------------------------------------
@@ -122,7 +122,7 @@ MainLoop:
 
 ProcessKey:
                 ld      hl,ModeTable
-                ld      a,(Mode)
+                ld      a,(mode)
                 add     a,a
                 add     hl,a
                 add     hl,a


### PR DESCRIPTION
1) setting SP to safe address (to get correct SNA file)
- snasm will overwrite three bytes at provided [address-2..address+0]
range, so $C000 will damage the included data/test.txt file.
(previous $7fff did damange interrupt vector table near $8000)

2) using PC instead of * will allow for simpler migration to other
assemblers (not a fix)

3) `mode` is defined in state.s, using `(Mode)` in case sensitive
assembler is a problem